### PR TITLE
Improve reliability of the prototype serial connection

### DIFF
--- a/firmware/haptick_proto/haptick_proto.ino
+++ b/firmware/haptick_proto/haptick_proto.ino
@@ -62,6 +62,9 @@ void setup()
   digitalWrite(spi_ncs_pin, HIGH);
   SPI.endTransaction();
 
+  // Wait for serial to come up
+  while (!Serial);
+
   // Set up an interrupt on the ADC_!DRDY pin
   attachInterrupt(digitalPinToInterrupt(adc_ndrdy_pin), adc_data_ready, FALLING);
 }


### PR DESCRIPTION
I'm really not sure what's going on, but it generally takes a lot of USB connects, disconnects, firmware flashes and faffing about to get a reliable serial stream of data from the Teensy.

I'm opening this PR in the hope that I can find the cause and fix it.