### PR TITLE
Delay configuration of the ADC

### DIFF
--- a/firmware/haptick_proto/haptick_proto.ino
+++ b/firmware/haptick_proto/haptick_proto.ino
@@ -39,6 +39,9 @@ void setup()
   analogWriteFrequency(adc_clk_pin, 8000000);
   analogWrite(adc_clk_pin, 128);
 
+  // Delay for a bit to make sure the ADC is alive
+  delay(100);
+
   // Start SPI and pull !CS high
   SPI.begin();
   pinMode(spi_ncs_pin, OUTPUT);


### PR DESCRIPTION
This is necessary on the latest prototype. I think the ADC is taking a little while to come up, and is missing the configuration sent to it without the delay.